### PR TITLE
Witty pi - move cleanup APT

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -147,7 +147,8 @@ apt-get  -o Dpkg::Options::=--force-confdef \
   pi-bluetooth \
   lsb-release \
   gettext \
-  cloud-init
+  cloud-init \
+  git
 
 
 # install special Docker enabled kernel
@@ -217,9 +218,8 @@ chmod +x usr/local/bin/rpi-serial-console
 # fix eth0 interface name
 ln -s /dev/null /etc/systemd/network/99-default.link
 
-# cleanup APT cache and lists
-apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# install I2C tools
+apt-get install i2c-tools
 
 # set device label and version number
 echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
@@ -227,11 +227,13 @@ echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
 cp /etc/os-release /boot/os-release
 
 # install Witty pi energy manager software
-echo "Installing i2c-tools"
-apt-get install i2c-tools
-mkdir /home/imvec
-cd /home/imvec
-echo "Installing Witty Pi 2 software"
+cd /home
 wget http://www.uugear.com/repo/WittyPi2/installWittyPi.sh
-sh installWittyPi.sh
+yes | sh installWittyPi.sh
+rm -rf /home/installWittyPi.sh
+
+# cleanup APT cache and lists
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # apt-get update


### PR DESCRIPTION
### What's this recipe about?
Witty pi mini is a Uugear RPi shield capable of managing energy of the RPi together with keeping time using an embedded RTC.

https://github.com/uugear/Witty-Pi-2

Together with the Calafou community we are working on a timelapse camera for river monitoring. First test are being carried out at the Anoia river close to Barcelona.

The intention is to turn on the rpi 5 minutes every hour and take a picture. Simple as that. The Witty pi controls the On/OFF of the RPi sending zero voltage to the Pi to fully turn it off. After 55 minutes the Witty sends a electrical signal and the Pi boots up.

![011](https://user-images.githubusercontent.com/22200702/47952482-4c0c3600-df70-11e8-8dbc-127ac645d2fd.jpg)

Set up of the very first ANOIAcam prototype over the Anoia river:
![anoiacam_setup_anoia](https://user-images.githubusercontent.com/22200702/47952877-326ded00-df76-11e8-9424-7e92272c34cb.jpg)

First picture of the Anoia river:
![21-38-20](https://user-images.githubusercontent.com/22200702/47881825-a9e13680-de27-11e8-8e32-6dbc4a1db40d.jpg)


Download instructions
Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image go to  https://gitlab.com/publiclab/image-builder-rpi/pipelines/#59/builds and click the green checkmark.
On this page, click the **Jobs** tab, next to **Pipeline**
Click the green **Passed** button
Click **Download** in the right-hand sidebar
Unzip the **artifacts.zip** file, and also the **hypriotos-rpi-camera_web.img.zip** within it
Use a program like https://etcher.io/ to flash it to an SD card
You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

#16

Thanks!